### PR TITLE
Updating Guice to version 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>twigkit</groupId>
     <artifactId>cachalot</artifactId>
-    <version>1.7-SNAPSHOT</version>
+    <version>1.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>cachalot</name>
     <description>Guice/AOP annotation to cache access to methods, and skip invocation for cached return value.

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>3.0</version>
+            <version>4.0</version>
         </dependency>
 
         <!-- ehcache -->


### PR DESCRIPTION
Guice 3 falls over in some instances when trying to process Java 8 lambda expressions. Guice 4 contains better runtime support for these features.